### PR TITLE
feat: Webpack config function and async module support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,7 +60,13 @@ yargs()
 			description: 'Watch mode',
 			group: INSTANT_MOCHA_OPTIONS_GROUP,
 		},
+		mode: {
+			description: 'Mode passed to webpack development|production',
+			group: INSTANT_MOCHA_OPTIONS_GROUP,
+			type: 'string',
+		},
 	})
+	.alias('m', 'mode')
 	.help('help', 'Show usage information & exit')
 	.alias('help', 'h')
 	.version('version', 'Show version number & exit', version)

--- a/src/instant-mocha.ts
+++ b/src/instant-mocha.ts
@@ -5,7 +5,7 @@ import webpack from 'webpack';
 import collectFiles from 'mocha/lib/cli/collect-files.js';
 import AggregateError from 'aggregate-error';
 import ansiEscapes from 'ansi-escapes';
-import { InstantMochaOptions } from './types';
+import { InstantMochaOptions, WebpackEnvironmentOptions, WebpackArgvOptions } from './types';
 import { runMocha } from './lib/mocha';
 import { createWebpackCompiler } from './lib/webpack';
 
@@ -25,8 +25,28 @@ export default async function instantMocha(
 
 	let webpackConfig: webpack.Configuration;
 	try {
-		// eslint-disable-next-line node/global-require
-		webpackConfig = require(webpackConfigPath);
+		// eslint-disable-next-line node/global-require, @typescript-eslint/no-var-requires
+		const config = require(webpackConfigPath);
+		if (typeof config === 'function') {
+			const environment = {} as WebpackEnvironmentOptions;
+			if (options.watch) {
+				environment.WEBPACK_WATCH = true;
+			} else {
+				environment.WEBPACK_BUILD = true;
+			}
+
+			const argv = {
+				mode: options.mode,
+				env: environment,
+			} as WebpackArgvOptions;
+
+			webpackConfig = config(environment, argv);
+		} else {
+			if (options.mode) {
+				config.mode = options.mode;
+			}
+			webpackConfig = config;
+		}
 	} catch {
 		throw new Error(`Faild to load Webpack configuration: ${webpackConfigPath}`);
 	}

--- a/src/lib/webpack.ts
+++ b/src/lib/webpack.ts
@@ -17,6 +17,8 @@ export function createWebpackCompiler(
 
 		// https://stackoverflow.com/a/64715069
 		publicPath: '',
+		// to override any possible custom paths in the webpack config
+		filename: 'main.js',
 
 		// For Node.js env
 		// https://webpack.js.org/configuration/output/#outputglobalobject

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,4 +2,13 @@ export type InstantMochaOptions = Mocha.MochaOptions & {
 	webpackConfig: string;
 	watch: boolean;
 	spec: string[];
+	mode: string;
 };
+export type WebpackEnvironmentOptions = {
+	WEBPACK_WATCH: boolean;
+	WEBPACK_BUILD: boolean;
+};
+export type WebpackArgvOptions = {
+	mode: string;
+	env: WebpackEnvironmentOptions;
+}


### PR DESCRIPTION
If you look at my commit comments I explain each one in good detail, but the top level changes were as following:

-Overwrite filename in webpack config to make sure main.js is at the root of the volume

-Support webpack config as a function, call it and added flag for mode that can be used to set the webpack mode

-the virtual module compile function was returning my module as a promise. I was investigating this after mocha kept saying 0 tests passed when running the cli. Not 100% sure why this is the case, but I would guess it has to do with the experimental top level await support I added to webpack to use in my application. Changed to use loadFilesAsync and loading the files before calling mocha run.

-Ran into an error in memfs where the parent was undefined in load function, just checked if it was undefined before calling hasMemFsInCallStack. Not sure why this is occuring for me and not any of your tests

All of these changes I had to make to have your cli work with my codebase, I used to use mocha-webpack but had to switch when upgrading to webpack 5.
