### PR TITLE
Mocha 9 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		]
 	},
 	"peerDependencies": {
-		"mocha": "^6.1.4 || ^8.3.2",
+		"mocha": "^6.1.4 || ^8.3.2 || ^9.0.0",
 		"webpack": "^4.40.0 || ^5.0.0"
 	},
 	"dependencies": {
@@ -63,7 +63,8 @@
 		"jest": "^27.3.1",
 		"lint-staged": "^11.2.6",
 		"lodash-es": "^4.17.21",
-		"mocha": "^8.3.2",
+		"mocha": "^9.1.3",
+		"mocha8": "npm:mocha@^8.3.2",
 		"typescript": "^4.5.2",
 		"webpack": "^5.35.1",
 		"webpack4": "npm:webpack@4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,8 @@ specifiers:
   lodash-es: ^4.17.21
   memfs: ^3.4.0
   minimist: ^1.2.5
-  mocha: ^8.3.2
+  mocha: ^9.1.3
+  mocha8: npm:mocha@^8.3.2
   source-map-support: ^0.5.21
   typescript: ^4.5.2
   webpack: ^5.35.1
@@ -47,7 +48,8 @@ devDependencies:
   jest: 27.3.1
   lint-staged: 11.2.6
   lodash-es: 4.17.21
-  mocha: 8.3.2
+  mocha: 9.1.3
+  mocha8: /mocha/8.3.2
   typescript: 4.5.2
   webpack: 5.35.1
   webpack4: /webpack/4.0.0
@@ -1137,12 +1139,6 @@ packages:
     hasBin: true
     dev: true
 
-  /acorn/8.5.0:
-    resolution: {integrity: sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-    dev: true
-
   /acorn/8.6.0:
     resolution: {integrity: sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==}
     engines: {node: '>=0.4.0'}
@@ -1206,10 +1202,6 @@ packages:
     resolution: {integrity: sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=}
     engines: {node: '>=4'}
     dev: true
-
-  /ansi-regex/5.0.0:
-    resolution: {integrity: sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==}
-    engines: {node: '>=8'}
 
   /ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1782,7 +1774,7 @@ packages:
       braces: 3.0.2
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
-      is-glob: 4.0.1
+      is-glob: 4.0.3
       normalize-path: 3.0.0
       readdirp: 3.5.0
     optionalDependencies:
@@ -1803,7 +1795,6 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
-    optional: true
 
   /chownr/1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -1875,14 +1866,14 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       slice-ansi: 3.0.0
-      string-width: 4.2.2
+      string-width: 4.2.3
     dev: true
 
   /cliui/7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
     dependencies:
-      string-width: 4.2.2
-      strip-ansi: 6.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
   /clone/2.1.2:
@@ -3255,7 +3246,7 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
     dependencies:
-      is-glob: 4.0.1
+      is-glob: 4.0.3
     dev: true
 
   /glob-to-regexp/0.4.1:
@@ -3264,6 +3255,17 @@ packages:
 
   /glob/7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.0.4
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: true
+
+  /glob/7.1.7:
+    resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -3831,6 +3833,11 @@ packages:
 
   /is-typedarray/1.0.0:
     resolution: {integrity: sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=}
+    dev: true
+
+  /is-unicode-supported/0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
     dev: true
 
   /is-weakref/1.0.1:
@@ -4426,6 +4433,13 @@ packages:
       argparse: 2.0.1
     dev: true
 
+  /js-yaml/4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+    dependencies:
+      argparse: 2.0.1
+    dev: true
+
   /jsdoctypeparser/9.0.0:
     resolution: {integrity: sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==}
     engines: {node: '>=10'}
@@ -4442,7 +4456,7 @@ packages:
         optional: true
     dependencies:
       abab: 2.0.5
-      acorn: 8.5.0
+      acorn: 8.6.0
       acorn-globals: 6.0.0
       cssom: 0.4.4
       cssstyle: 2.3.0
@@ -4696,7 +4710,15 @@ packages:
     resolution: {integrity: sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==}
     engines: {node: '>=10'}
     dependencies:
-      chalk: 4.1.1
+      chalk: 4.1.2
+    dev: true
+
+  /log-symbols/4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
     dev: true
 
   /log-update/4.0.0:
@@ -4955,6 +4977,37 @@ packages:
       yargs-unparser: 2.0.0
     dev: true
 
+  /mocha/9.1.3:
+    resolution: {integrity: sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==}
+    engines: {node: '>= 12.0.0'}
+    hasBin: true
+    dependencies:
+      '@ungap/promise-all-settled': 1.1.2
+      ansi-colors: 4.1.1
+      browser-stdout: 1.3.1
+      chokidar: 3.5.2
+      debug: 4.3.2_supports-color@8.1.1
+      diff: 5.0.0
+      escape-string-regexp: 4.0.0
+      find-up: 5.0.0
+      glob: 7.1.7
+      growl: 1.10.5
+      he: 1.2.0
+      js-yaml: 4.1.0
+      log-symbols: 4.1.0
+      minimatch: 3.0.4
+      ms: 2.1.3
+      nanoid: 3.1.25
+      serialize-javascript: 6.0.0
+      strip-json-comments: 3.1.1
+      supports-color: 8.1.1
+      which: 2.0.2
+      workerpool: 6.1.5
+      yargs: 16.2.0
+      yargs-parser: 20.2.4
+      yargs-unparser: 2.0.0
+    dev: true
+
   /move-concurrently/1.0.1:
     resolution: {integrity: sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=}
     dependencies:
@@ -4989,6 +5042,12 @@ packages:
 
   /nanoid/3.1.20:
     resolution: {integrity: sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
+  /nanoid/3.1.25:
+    resolution: {integrity: sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
@@ -5392,11 +5451,6 @@ packages:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
     dev: true
 
-  /picomatch/2.2.3:
-    resolution: {integrity: sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==}
-    engines: {node: '>=8.6'}
-    dev: true
-
   /picomatch/2.3.0:
     resolution: {integrity: sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==}
     engines: {node: '>=8.6'}
@@ -5651,7 +5705,7 @@ packages:
     resolution: {integrity: sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==}
     engines: {node: '>=8.10.0'}
     dependencies:
-      picomatch: 2.2.3
+      picomatch: 2.3.0
     dev: true
 
   /readdirp/3.6.0:
@@ -5660,7 +5714,6 @@ packages:
     dependencies:
       picomatch: 2.3.0
     dev: true
-    optional: true
 
   /refa/0.9.1:
     resolution: {integrity: sha512-egU8LgFq2VXlAfUi8Jcbr5X38wEOadMFf8tCbshgcpVCYlE7k84pJOSlnvXF+muDB4igkdVMq7Z/kiNPqDT9TA==}
@@ -5923,6 +5976,12 @@ packages:
       randombytes: 2.1.0
     dev: true
 
+  /serialize-javascript/6.0.0:
+    resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
+    dependencies:
+      randombytes: 2.1.0
+    dev: true
+
   /set-value/2.0.1:
     resolution: {integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==}
     engines: {node: '>=0.10.0'}
@@ -6177,7 +6236,7 @@ packages:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.0
+      strip-ansi: 6.0.1
 
   /string-width/4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -6246,7 +6305,8 @@ packages:
     resolution: {integrity: sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==}
     engines: {node: '>=8'}
     dependencies:
-      ansi-regex: 5.0.0
+      ansi-regex: 5.0.1
+    dev: true
 
   /strip-ansi/6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -6322,8 +6382,8 @@ packages:
       lodash.clonedeep: 4.5.0
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
-      string-width: 4.2.2
-      strip-ansi: 6.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
     dev: true
 
   /tapable/1.1.3:
@@ -6898,6 +6958,10 @@ packages:
 
   /workerpool/6.1.0:
     resolution: {integrity: sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==}
+    dev: true
+
+  /workerpool/6.1.5:
+    resolution: {integrity: sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==}
     dev: true
 
   /wrap-ansi/6.2.0:

--- a/tests/instant-mocha.spec.ts
+++ b/tests/instant-mocha.spec.ts
@@ -17,14 +17,18 @@ const collectStdout = (buffers: Buffer[]) => new Promise<string>(
 	},
 );
 const instantMocha = path.resolve('./bin/instant-mocha.js');
+const mocha8RequireArguments = ['-r', '../use-mocha8.js'];
+const webpack4RequireArguments = ['-r', '../use-webpack4.js'];
 
 describe.each([
-	['Webpack 5', []],
-	['Webpack 4', ['-r', '../use-webpack4.js']],
-])('%s', (_name, webpackVersion) => {
+	['Webpack 5 & Mocha 9', []],
+	['Webpack 5 & Mocha 8', [...mocha8RequireArguments]],
+	['Webpack 4 & Mocha 9', [...webpack4RequireArguments]],
+	['Webpack 4 & Mocha 8', [...webpack4RequireArguments, ...mocha8RequireArguments]],
+])('%s', (_name, extraArguments) => {
 	test('running tests', async () => {
 		const { exitCode, stdout } = await execa('node', [
-			...webpackVersion,
+			...extraArguments,
 			instantMocha,
 			'--webpackConfig',
 			'webpack.config.js',
@@ -39,7 +43,7 @@ describe.each([
 
 	test('exit-code on failure', async () => {
 		const { exitCode, stdout } = await execa('node', [
-			...webpackVersion,
+			...extraArguments,
 			instantMocha,
 			'--webpackConfig',
 			'webpack.config.js',
@@ -54,7 +58,7 @@ describe.each([
 
 	test('custom reporter', async () => {
 		const { exitCode, stdout } = await execa('node', [
-			...webpackVersion,
+			...extraArguments,
 			instantMocha,
 			'--webpackConfig',
 			'webpack.config.js',
@@ -71,7 +75,7 @@ describe.each([
 
 	test('dynamic import', async () => {
 		const { exitCode, stdout } = await execa('node', [
-			...webpackVersion,
+			...extraArguments,
 			instantMocha,
 			'--webpackConfig',
 			'webpack.config.js',
@@ -86,7 +90,7 @@ describe.each([
 
 	test('custom assertion library - chai', async () => {
 		const { exitCode, stdout } = await execa('node', [
-			...webpackVersion,
+			...extraArguments,
 			instantMocha,
 			'--webpackConfig',
 			'webpack.config.js',
@@ -101,7 +105,7 @@ describe.each([
 
 	test('function config', async () => {
 		const { exitCode, stdout } = await execa('node', [
-			...webpackVersion,
+			...extraArguments,
 			instantMocha,
 			'--webpackConfig',
 			'webpack.config.function.js',
@@ -116,7 +120,7 @@ describe.each([
 
 	test('esm config', async () => {
 		const { exitCode, stdout } = await execa('node', [
-			...webpackVersion,
+			...extraArguments,
 			instantMocha,
 			'--webpackConfig',
 			'webpack.config.esm.mjs',
@@ -133,7 +137,7 @@ describe.each([
 		const stdoutBuffers = [];
 
 		const instantMochaWatch = execa('node', [
-			...webpackVersion,
+			...extraArguments,
 			instantMocha,
 			'--webpackConfig',
 			'webpack.config.js',

--- a/tests/use-mocha8.js
+++ b/tests/use-mocha8.js
@@ -1,0 +1,7 @@
+const Module = require('module');
+
+const { require: originalRequire } = Module.prototype;
+Module.prototype.require = function (specifier) {
+	specifier = specifier.replace(/^mocha(\/.+)?$/, 'mocha8$1');
+	return originalRequire.call(this, specifier);
+};


### PR DESCRIPTION
From my limited testing, mocha 9 works fine as it is. It just needs to be added as an acceptable peer dependency.

Closes #34