### PR TITLE
Webpack-config default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Note: `webpack` and `mocha` are peer-dependencies so you can provide any version
 
 ## 👨‍🏫 Usage
 ```sh
-instant-mocha --webpack-config <Webpack config path> [test paths/globs...]
+instant-mocha [test paths/globs...]
 ```
 
 You can either use [`npx`](https://www.npmjs.com/package/npx) (eg. `npx instant-mocha ...`) or add it to [`package.json` scripts](https://nodejs.dev/learn/the-package-json-guide) (eg. `npm test`) to invoke it. 

--- a/src/instant-mocha.ts
+++ b/src/instant-mocha.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import assert from 'assert';
 import collectFiles from 'mocha/lib/cli/collect-files.js';
 import AggregateError from 'aggregate-error';
 import ansiEscapes from 'ansi-escapes';
@@ -11,12 +10,7 @@ import { getWebpackConfig } from './lib/get-webpack-config';
 export default async function instantMocha(
 	options: InstantMochaOptions,
 ): Promise<number> {
-	assert(
-		options.webpackConfig,
-		'Webpack configuration path must be passed in',
-	);
-
-	const webpackConfigPath = path.resolve(options.webpackConfig);
+	const webpackConfigPath = path.resolve(options.webpackConfig || 'webpack.config.js');
 	const webpackConfig = await getWebpackConfig(webpackConfigPath, options);
 
 	const testFiles = collectFiles({

--- a/tests/instant-mocha.spec.ts
+++ b/tests/instant-mocha.spec.ts
@@ -26,8 +26,6 @@ describe.each([
 		const { exitCode, stdout } = await execa('node', [
 			...webpackVersion,
 			instantMocha,
-			'--webpackConfig',
-			'webpack.config.js',
 			'tests/passing-test.js',
 		], {
 			cwd: path.resolve('tests/fixture'),
@@ -41,8 +39,6 @@ describe.each([
 		const { exitCode, stdout } = await execa('node', [
 			...webpackVersion,
 			instantMocha,
-			'--webpackConfig',
-			'webpack.config.js',
 			'tests/failing-test.js',
 		], {
 			cwd: path.resolve('tests/fixture'),
@@ -56,8 +52,6 @@ describe.each([
 		const { exitCode, stdout } = await execa('node', [
 			...webpackVersion,
 			instantMocha,
-			'--webpackConfig',
-			'webpack.config.js',
 			'--reporter',
 			'custom-reporter.js',
 			'tests/failing-test.js',
@@ -73,8 +67,6 @@ describe.each([
 		const { exitCode, stdout } = await execa('node', [
 			...webpackVersion,
 			instantMocha,
-			'--webpackConfig',
-			'webpack.config.js',
 			'tests/dynamic-import-test.js',
 		], {
 			cwd: path.resolve('tests/fixture'),
@@ -88,8 +80,6 @@ describe.each([
 		const { exitCode, stdout } = await execa('node', [
 			...webpackVersion,
 			instantMocha,
-			'--webpackConfig',
-			'webpack.config.js',
 			'tests/using-chai.js',
 		], {
 			cwd: path.resolve('tests/fixture'),
@@ -135,8 +125,6 @@ describe.each([
 		const instantMochaWatch = execa('node', [
 			...webpackVersion,
 			instantMocha,
-			'--webpackConfig',
-			'webpack.config.js',
 			'tests/passing-test.js',
 			'--watch',
 		], {


### PR DESCRIPTION
I think it's reasonable to default to using `webpack.config.js` instead of having `--webpack-config` as a required cli argument, since even the webpack cli defaults to it itself.