### PR TITLE
fix: set output.module to false

### DIFF
--- a/src/lib/webpack.ts
+++ b/src/lib/webpack.ts
@@ -23,7 +23,7 @@ export function createWebpackCompiler(
 		// For Node.js env
 		// https://webpack.js.org/configuration/output/#outputglobalobject
 		globalObject: 'this',
-		module: false,
+		module: undefined,
 		libraryTarget: 'commonjs2',
 	};
 


### PR DESCRIPTION
Since the library target is being forced to CJS, module flag cannot be true.  Fixes #49 but perhaps handling ESM output should be considered as a follow up.