### PR TITLE
fix: source maps to work correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,10 @@
 		"webpack": "4 || 5"
 	},
 	"dependencies": {
+		"@cspotcode/source-map-support": "^0.8.1",
 		"fs-require": "^1.6.0",
 		"memfs": "^3.5.0",
-		"source-map-support": "^0.5.21",
+		"source-map-url": "^0.4.1",
 		"yargs": "^16.2.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
 		"@cspotcode/source-map-support": "^0.8.1",
 		"fs-require": "^1.6.0",
 		"memfs": "^3.5.0",
-		"source-map-url": "^0.4.1",
 		"yargs": "^16.2.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ dependencies:
   memfs:
     specifier: ^3.5.0
     version: 3.5.0
-  source-map-url:
-    specifier: ^0.4.1
-    version: 0.4.1
   yargs:
     specifier: ^16.2.0
     version: 16.2.0
@@ -4048,13 +4045,6 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
-  /json5@1.0.1:
-    resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
-    hasBin: true
-    dependencies:
-      minimist: 1.2.8
-    dev: true
-
   /json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -5724,6 +5714,7 @@ packages:
   /source-map-url@0.4.1:
     resolution: {integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==}
     deprecated: See https://github.com/lydell/source-map-url#deprecated
+    dev: true
 
   /source-map@0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
@@ -6107,7 +6098,7 @@ packages:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
       '@types/json5': 0.0.29
-      json5: 1.0.1
+      json5: 1.0.2
       minimist: 1.2.8
       strip-bom: 3.0.0
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,15 +1,22 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
+  '@cspotcode/source-map-support':
+    specifier: ^0.8.1
+    version: 0.8.1
   fs-require:
     specifier: ^1.6.0
     version: 1.6.0
   memfs:
     specifier: ^3.5.0
     version: 3.5.0
-  source-map-support:
-    specifier: ^0.5.21
-    version: 0.5.21
+  source-map-url:
+    specifier: ^0.4.1
+    version: 0.4.1
   yargs:
     specifier: ^16.2.0
     version: 16.2.0
@@ -104,6 +111,13 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: true
+
+  /@cspotcode/source-map-support@0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: false
 
   /@esbuild-kit/cjs-loader@2.4.2:
     resolution: {integrity: sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==}
@@ -425,9 +439,20 @@ packages:
       chalk: 4.1.2
     dev: true
 
+  /@jridgewell/resolve-uri@3.1.1:
+    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
+    engines: {node: '>=6.0.0'}
+    dev: false
+
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
+
+  /@jridgewell/trace-mapping@0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: false
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1192,6 +1217,7 @@ packages:
 
   /anymatch@2.0.0:
     resolution: {integrity: sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==}
+    requiresBuild: true
     dependencies:
       micromatch: 3.1.10
       normalize-path: 2.1.1
@@ -1304,6 +1330,7 @@ packages:
 
   /async-each@1.0.6:
     resolution: {integrity: sha512-c646jH1avxr+aVpndVMeAfYw7wAa6idufrlN3LPA4PmKS0QEGp6PIC9nwz0WQkkvBGAMEki3pFdtxaF39J9vvg==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1341,6 +1368,7 @@ packages:
   /binary-extensions@1.13.1:
     resolution: {integrity: sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1351,6 +1379,7 @@ packages:
 
   /bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    requiresBuild: true
     dependencies:
       file-uri-to-path: 1.0.0
     dev: true
@@ -1487,6 +1516,7 @@ packages:
 
   /buffer-from@1.1.1:
     resolution: {integrity: sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==}
+    dev: true
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -1623,6 +1653,7 @@ packages:
   /chokidar@2.1.8:
     resolution: {integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==}
     deprecated: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
+    requiresBuild: true
     dependencies:
       anymatch: 2.0.0
       async-each: 1.0.6
@@ -2152,7 +2183,7 @@ packages:
     resolution: {integrity: sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==}
     engines: {node: '>=10.13.0'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       tapable: 2.2.1
     dev: true
 
@@ -3037,6 +3068,7 @@ packages:
 
   /file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -3162,7 +3194,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
@@ -3245,6 +3277,7 @@ packages:
 
   /glob-parent@3.1.0:
     resolution: {integrity: sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==}
+    requiresBuild: true
     dependencies:
       is-glob: 3.1.0
       path-dirname: 1.0.2
@@ -3275,7 +3308,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
@@ -3596,6 +3629,7 @@ packages:
   /is-binary-path@1.0.1:
     resolution: {integrity: sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       binary-extensions: 1.13.1
     dev: true
@@ -3735,6 +3769,7 @@ packages:
   /is-glob@3.1.0:
     resolution: {integrity: sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       is-extglob: 2.1.1
     dev: true
@@ -3936,7 +3971,7 @@ packages:
       '@jest/types': 29.3.1
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       micromatch: 4.0.5
       pretty-format: 29.3.1
       slash: 3.0.0
@@ -3951,7 +3986,7 @@ packages:
       '@types/node': 18.11.9
       chalk: 4.1.2
       ci-info: 3.6.1
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       picomatch: 2.3.1
     dev: true
 
@@ -4017,7 +4052,7 @@ packages:
     resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
     hasBin: true
     dependencies:
-      minimist: 1.2.7
+      minimist: 1.2.8
     dev: true
 
   /json5@1.0.2:
@@ -4446,10 +4481,6 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
-  /minimist@1.2.7:
-    resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
-    dev: true
-
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
@@ -4601,6 +4632,7 @@ packages:
 
   /nan@2.17.0:
     resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -4697,6 +4729,7 @@ packages:
   /normalize-path@2.1.1:
     resolution: {integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       remove-trailing-separator: 1.1.0
     dev: true
@@ -4959,6 +4992,7 @@ packages:
 
   /path-dirname@1.0.2:
     resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -5254,6 +5288,7 @@ packages:
   /readdirp@2.2.1:
     resolution: {integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==}
     engines: {node: '>=0.10'}
+    requiresBuild: true
     dependencies:
       graceful-fs: 4.2.11
       micromatch: 3.1.10
@@ -5326,6 +5361,7 @@ packages:
 
   /remove-trailing-separator@1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -5683,11 +5719,11 @@ packages:
     dependencies:
       buffer-from: 1.1.1
       source-map: 0.6.1
+    dev: true
 
   /source-map-url@0.4.1:
     resolution: {integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==}
     deprecated: See https://github.com/lydell/source-map-url#deprecated
-    dev: true
 
   /source-map@0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
@@ -5697,6 +5733,7 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
@@ -5995,7 +6032,7 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      acorn: 8.8.1
+      acorn: 8.8.2
       commander: 2.20.3
       source-map: 0.7.4
       source-map-support: 0.5.21
@@ -6071,7 +6108,7 @@ packages:
     dependencies:
       '@types/json5': 0.0.29
       json5: 1.0.1
-      minimist: 1.2.7
+      minimist: 1.2.8
       strip-bom: 3.0.0
     dev: true
 
@@ -6202,6 +6239,7 @@ packages:
   /upath@1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -6300,7 +6338,7 @@ packages:
     engines: {node: '>=10.13.0'}
     dependencies:
       glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: true
 
   /webpack-sources@1.4.3:

--- a/src/lib/memfs.ts
+++ b/src/lib/memfs.ts
@@ -9,11 +9,23 @@ export const mfs = createFsFromVolume(new Volume());
 // @ts-expect-error To support Webpack 4. No longer needed in WP5
 mfs.join = path.join;
 
+let id: number;
+
+export const mRequire = (modulePath: string): any => {
+	const require =createFsRequire(mfs, {
+		fs: true,
+	});
+
+	id = require.id;
+
+	return require(modulePath);
+};
+
 function removeFsRequirePrefix(filePath: string) {
-	const fsRequirePrefix = 'fs-require://1';
+	const fsRequirePrefix = `fs-require://${id}/`;
 
 	if (filePath.startsWith(fsRequirePrefix)) {
-		return filePath.slice(fsRequirePrefix.length);
+		return filePath.slice(fsRequirePrefix.length - 1);
 	}
 
 	return filePath;
@@ -53,9 +65,3 @@ sourceMapSupport.install({
 		return null;
 	},
 });
-
-export const mRequire = (modulePath: string): any => (
-	createFsRequire(mfs, {
-		fs: true,
-	})(modulePath)
-);

--- a/src/lib/memfs.ts
+++ b/src/lib/memfs.ts
@@ -12,7 +12,7 @@ mfs.join = path.join;
 let id: number;
 
 export const mRequire = (modulePath: string): any => {
-	const require =createFsRequire(mfs, {
+	const require = createFsRequire(mfs, {
 		fs: true,
 	});
 

--- a/src/lib/memfs.ts
+++ b/src/lib/memfs.ts
@@ -1,19 +1,56 @@
 import path from 'path';
 import { createFsFromVolume, Volume } from 'memfs';
 import { createFsRequire } from 'fs-require';
-import sourceMapSupport from 'source-map-support';
+import sourceMapSupport from '@cspotcode/source-map-support';
+import sourceMappingURL from 'source-map-url';
 
 export const mfs = createFsFromVolume(new Volume());
 
 // @ts-expect-error To support Webpack 4. No longer needed in WP5
 mfs.join = path.join;
 
+function removeFsRequirePrefix(filePath: string) {
+	const fsRequirePrefix = 'fs-require://1';
+
+	if (filePath.startsWith(fsRequirePrefix)) {
+		return filePath.slice(fsRequirePrefix.length);
+	}
+
+	return filePath;
+}
+
 sourceMapSupport.install({
 	environment: 'node',
 	retrieveFile(filePath: string) {
-		if (mfs.existsSync(filePath)) {
-			return mfs.readFileSync(filePath).toString();
+		const filteredFilePath = removeFsRequirePrefix(filePath);
+
+		if (mfs.existsSync(filteredFilePath)) {
+			return mfs.readFileSync(filteredFilePath).toString();
 		}
+	},
+	retrieveSourceMap(sourceFilePath: string) {
+		const filteredSourceFilePath = removeFsRequirePrefix(sourceFilePath);
+
+		if (mfs.existsSync(filteredSourceFilePath)) {
+			const sourceFileContent = mfs.readFileSync(filteredSourceFilePath).toString();
+			const sourceMapFilePath = sourceMappingURL.getFrom(sourceFileContent);
+
+			if (sourceMapFilePath === null) {
+				return null;
+			}
+
+			const parentDirectory = path.dirname(filteredSourceFilePath);
+			const sourceMapFileFullPath = `${parentDirectory}/${sourceMapFilePath}`;
+
+			if (mfs.existsSync(sourceMapFileFullPath)) {
+				return {
+					url: sourceFilePath,
+					map: mfs.readFileSync(sourceMapFileFullPath).toString(),
+				};
+			}
+		}
+
+		return null;
 	},
 });
 

--- a/src/lib/memfs.ts
+++ b/src/lib/memfs.ts
@@ -20,23 +20,17 @@ export const mRequire = (modulePath: string): any => {
 	return require(modulePath);
 };
 
-function removeFsRequirePrefix(filePath: string) {
-	const fsRequirePrefix = `fs-require://${id}/`;
-
-	if (filePath.startsWith(fsRequirePrefix)) {
-		return filePath.slice(fsRequirePrefix.length - 1);
-	}
-
-	return filePath;
-}
-
 sourceMapSupport.install({
 	environment: 'node',
 	retrieveFile(filePath: string) {
-		const filteredFilePath = removeFsRequirePrefix(filePath);
+		const fsRequirePrefix = `fs-require://${id}/`;
 
-		if (mfs.existsSync(filteredFilePath)) {
-			return mfs.readFileSync(filteredFilePath).toString();
+		if (filePath.startsWith(fsRequirePrefix)) {
+			filePath = filePath.slice(fsRequirePrefix.length - 1);
+		}
+
+		if (mfs.existsSync(filePath)) {
+			return mfs.readFileSync(filePath).toString();
 		}
 	},
 });

--- a/src/lib/memfs.ts
+++ b/src/lib/memfs.ts
@@ -2,7 +2,6 @@ import path from 'path';
 import { createFsFromVolume, Volume } from 'memfs';
 import { createFsRequire } from 'fs-require';
 import sourceMapSupport from '@cspotcode/source-map-support';
-import sourceMappingURL from 'source-map-url';
 
 export const mfs = createFsFromVolume(new Volume());
 
@@ -39,29 +38,5 @@ sourceMapSupport.install({
 		if (mfs.existsSync(filteredFilePath)) {
 			return mfs.readFileSync(filteredFilePath).toString();
 		}
-	},
-	retrieveSourceMap(sourceFilePath: string) {
-		const filteredSourceFilePath = removeFsRequirePrefix(sourceFilePath);
-
-		if (mfs.existsSync(filteredSourceFilePath)) {
-			const sourceFileContent = mfs.readFileSync(filteredSourceFilePath).toString();
-			const sourceMapFilePath = sourceMappingURL.getFrom(sourceFileContent);
-
-			if (sourceMapFilePath === null) {
-				return null;
-			}
-
-			const parentDirectory = path.dirname(filteredSourceFilePath);
-			const sourceMapFileFullPath = `${parentDirectory}/${sourceMapFilePath}`;
-
-			if (mfs.existsSync(sourceMapFileFullPath)) {
-				return {
-					url: sourceFilePath,
-					map: mfs.readFileSync(sourceMapFileFullPath).toString(),
-				};
-			}
-		}
-
-		return null;
 	},
 });


### PR DESCRIPTION
Hi,

I was experimenting with this nice tool of yours but I could not manage to get a usable stack trace by following the instructions of the `README.md` at [How do I enable source-maps?](https://github.com/privatenumber/instant-mocha/blob/develop/README.md#how-do-i-enable-source-maps).

Here's my attempt at fixing this issue :)

This PR replaces `source-map-support` with the more up to date `@cspotcode/source-map-support` fork.
See [this issue on Github](https://github.com/cspotcode/node-source-map-support/issues/24) for the differences between the two.

It also adds a dependency to `source-map-url` which I use to parse the compiled sources to get the URL of the source map file.

This PR also includes tests for different source map types.
