### PR TITLE
fix: use `files` array for Mocha 10 (fix #53)

### DIFF
--- a/src/instant-mocha.ts
+++ b/src/instant-mocha.ts
@@ -41,7 +41,7 @@ export default async function instantMocha(
 
 	const webpackCompiler = createWebpackCompiler(
 		webpackConfig,
-		Array.isArray(testFiles) ? testFiles : testFiles.files
+		Array.isArray(testFiles) ? testFiles : testFiles.files,
 	);
 
 	if (options.watch) {

--- a/src/instant-mocha.ts
+++ b/src/instant-mocha.ts
@@ -39,7 +39,7 @@ export default async function instantMocha(
 		});
 	}
 
-	const webpackCompiler = createWebpackCompiler(webpackConfig, testFiles);
+	const webpackCompiler = createWebpackCompiler(webpackConfig, testFiles.files);
 
 	if (options.watch) {
 		webpackCompiler.watch({}, (error, stats) => {

--- a/src/instant-mocha.ts
+++ b/src/instant-mocha.ts
@@ -39,7 +39,7 @@ export default async function instantMocha(
 		});
 	}
 
-	const webpackCompiler = createWebpackCompiler(webpackConfig, testFiles.files);
+	const webpackCompiler = createWebpackCompiler(webpackConfig, Array.isArray(testFiles) ? testFiles : testFiles.files);
 
 	if (options.watch) {
 		webpackCompiler.watch({}, (error, stats) => {

--- a/src/instant-mocha.ts
+++ b/src/instant-mocha.ts
@@ -39,7 +39,10 @@ export default async function instantMocha(
 		});
 	}
 
-	const webpackCompiler = createWebpackCompiler(webpackConfig, Array.isArray(testFiles) ? testFiles : testFiles.files);
+	const webpackCompiler = createWebpackCompiler(
+		webpackConfig,
+		Array.isArray(testFiles) ? testFiles : testFiles.files
+	);
 
 	if (options.watch) {
 		webpackCompiler.watch({}, (error, stats) => {


### PR DESCRIPTION
Starting from Mocha v10.5.1 `collectFiles()` now returns an object that contains entries for both existing and non-existing files.
See https://github.com/mochajs/mocha/commit/dbe229d1b7ce672a02992b12ecb38a1cdd440a1e

This changed behavior is the reason why webpack does not accept the configuration and throws the following error:
> ValidationError: Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.